### PR TITLE
Update GeoBaseModule.py

### DIFF
--- a/GeoBases/GeoBaseModule.py
+++ b/GeoBases/GeoBaseModule.py
@@ -344,7 +344,7 @@ class GeoBase(object):
                     continue
 
                 try:
-                    with open(file_) as source_fl:
+                    with open(file_, encoding="utf-8") as source_fl:
                         self._load(source_fl, self._verbose)
                 except IOError:
                     if self._verbose:


### PR DESCRIPTION
Hello,

The following command gives the following error on Windows platform:

>>> from GeoBases import GeoBase
>>> geo_a = GeoBase(data='airports', verbose=False)

UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 728: character maps to <undefined>